### PR TITLE
feat: chunked evaluation to reduce memory

### DIFF
--- a/eval.py
+++ b/eval.py
@@ -54,6 +54,7 @@ def main():
 
     parser.add_argument('--num_chunks', type=str, default="1")
     parser.add_argument('--chunk_idx', type=str, default="0")
+    parser.add_argument('--eval_batch_size', type=int, default=2000, help='batch size for dataset evaluation')
 
     parser.add_argument('--max_image_num', type=int, default=1)
     parser.add_argument('--max_new_tokens', type=int, default=1024)
@@ -97,15 +98,16 @@ def main():
     os.environ["NCCL_IGNORE_DISABLED_P2P"] = "1"
     if args.cuda_visible_devices is not None:
         os.environ["CUDA_VISIBLE_DEVICES"] = args.cuda_visible_devices
+    os.environ["tensor_parallel_size"] = args.tensor_parallel_size
+    os.environ["num_chunks"] = args.num_chunks
+    os.environ["chunk_idx"] = args.chunk_idx
+    os.environ["BATCH_SIZE"] = str(args.eval_batch_size)
     if args.use_vllm == "True":
-        os.environ["tensor_parallel_size"] = args.tensor_parallel_size
         if int(args.tensor_parallel_size) > 1:
             os.environ["VLLM_WORKER_MULTIPROC_METHOD"] = "spawn"
             os.environ["TOKENIZERS_PARALLELISM"] = "false"
     else:
         torch.multiprocessing.set_start_method('spawn')
-        os.environ["num_chunks"] = args.num_chunks
-        os.environ["chunk_idx"] = args.chunk_idx
 
 
     os.makedirs(args.output_path, exist_ok=True)

--- a/eval.sh
+++ b/eval.sh
@@ -19,6 +19,7 @@ USE_VLLM="True" #True
 SEED=42
 REASONING="False"
 TEST_TIMES=1
+BATCH_SIZE=8
 
 
 # Eval LLM setting
@@ -50,6 +51,7 @@ python eval.py \
     --max-model-len 16032 \
     --max_new_tokens "$MAX_NEW_TOKENS" \
     --max_image_num "$MAX_IMAGE_NUM" \
+    --eval_batch_size "$BATCH_SIZE" \
     --temperature "$TEMPERATURE"  \
     --top_p "$TOP_P" \
     --repetition_penalty "$REPETITION_PENALTY" \

--- a/utils/MedXpertQA/MedXpertQA.py
+++ b/utils/MedXpertQA/MedXpertQA.py
@@ -3,7 +3,6 @@ import os
 import json
 import gc
 
-from PIL import Image
 from datasets import load_dataset
 from collections import defaultdict
 from tqdm import tqdm
@@ -48,7 +47,6 @@ class MedXpertQA(BaseDataset):
         if "images" in sample:
             images = sample["images"]
             images = [os.path.join(self.dataset_path,"images",image) for image in images]
-            images = [Image.open(image) for image in images]
             messages = {"prompt":prompt,"images":images}
             del sample["images"]
         else:


### PR DESCRIPTION
## Summary
- load evaluation images on-the-fly to avoid high RAM usage
- expose configurable batch size and chunk parameters even when using vLLM
- default eval script uses smaller batch size for heavy datasets

## Testing
- `python -m py_compile eval.py utils/base_dataset.py utils/MedXpertQA/MedXpertQA.py`
- `bash -n eval.sh`


------
https://chatgpt.com/codex/tasks/task_e_68962c7cc90c833091b774238d9e5ec3